### PR TITLE
Restriction Ruby to version 3.1

### DIFF
--- a/.github/workflows/fetcher.yml
+++ b/.github/workflows/fetcher.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Use Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.1.0
       - name: Install gem
         run: |
           gem install relaton-cli


### PR DESCRIPTION
The rdf gem doesn't work with Ruby c 3.2 yet.